### PR TITLE
Add concurrency block

### DIFF
--- a/.github/workflows/sync_forks.yml
+++ b/.github/workflows/sync_forks.yml
@@ -5,6 +5,11 @@ on:
   schedule:
     - cron: '0 */4 * * *'
 
+# Add concurrency to prevent multiple runs interfering with each other
+concurrency:
+  group: sync-forks
+  cancel-in-progress: true
+
 jobs:
   sync-forks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add concurrency section to sync_forks workflow

## Testing
- `pre-commit` *(fails: command not found)*
